### PR TITLE
Check email before checking name

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -21,15 +21,14 @@ type slackUsers []slackUser
 func (users slackUsers) findByPDUser(pdUser pagerduty.User) *slackUser {
 	// check email match first since it's a distinctive identifier
 	for _, slackUser := range users {
-		if slackUser.email == pdUser.Email { 
+		if slackUser.email == pdUser.Email {
 			return &slackUser
 		}
 	}
 
 	// if we couldn't find an email match, use name. this is the second choice as name is not unique in an organization
 	for _, slackUser := range users {
-		if
-		slackUser.realName == strings.ToLower(pdUser.Name) ||
+		if slackUser.realName == strings.ToLower(pdUser.Name) ||
 			slackUser.name == strings.ToLower(pdUser.Name) {
 			return &slackUser
 		}

--- a/slack.go
+++ b/slack.go
@@ -19,9 +19,17 @@ import (
 type slackUsers []slackUser
 
 func (users slackUsers) findByPDUser(pdUser pagerduty.User) *slackUser {
+	// check email match first since it's a distinctive identifier
 	for _, slackUser := range users {
-		if slackUser.email == pdUser.Email ||
-			slackUser.realName == strings.ToLower(pdUser.Name) ||
+		if slackUser.email == pdUser.Email { 
+			return &slackUser
+		}
+	}
+
+	// if we couldn't find an email match, use name. this is the second choice as name is not unique in an organization
+	for _, slackUser := range users {
+		if
+		slackUser.realName == strings.ToLower(pdUser.Name) ||
 			slackUser.name == strings.ToLower(pdUser.Name) {
 			return &slackUser
 		}


### PR DESCRIPTION
As discussed with @timoreimann we found a case where due checking email/name at the same time, we got the wrong person. The case was as such

If there's a list of users with the format name, email

Right Name, wrong@test.com
Right Name, right@test.com

where both users have the same name but the second user in the list is the one we actually want (by email), the current logic will select the wrong user due to the name match.

We agreed that checking email first and then falling back to name if we can't find a match will fix this behavior while preserving name based search for those who use it.