### PR TITLE
Support maximum daemon execution time

### DIFF
--- a/daemon.go
+++ b/daemon.go
@@ -7,13 +7,13 @@ import (
 	"time"
 )
 
-func daemonRun(ctx context.Context, freq time.Duration, f func() error) {
+func startDaemon(ctx context.Context, freq time.Duration, f func() error) {
 	ticker := time.NewTicker(freq)
 	defer ticker.Stop()
 
 	errLogF := func() {
 		err := f()
-		if err != nil {
+		if err != nil && ctx.Err() == nil {
 			fmt.Fprintln(os.Stderr, err)
 		}
 	}

--- a/kubernetes/deployment.yaml
+++ b/kubernetes/deployment.yaml
@@ -37,6 +37,8 @@ spec:
           - --config
           - /config/config.yaml
           - --daemon
+          # Trigger restart after 24h to force Slack data and PagerDuty schedule updates.
+          - --daemon-max-execution-time=1440m
           - --dry-run
         volumeMounts:
           - name: pdsync


### PR DESCRIPTION
Enables a simple way to force a Slack data and PagerDuty schedule update through a restart.