### PR TITLE
Short-circuit Slack sync runs on context expiry

### DIFF
--- a/syncer.go
+++ b/syncer.go
@@ -115,7 +115,7 @@ func (s *syncer) Run(ctx context.Context, slackSyncs []runSlackSync, failFast bo
 		err := s.runSlackSync(ctx, slackSync)
 		if err != nil {
 			msg := fmt.Sprintf("failed to run Slack sync %s: %s", slackSync.name, err)
-			if failFast {
+			if failFast || ctx.Err() != nil {
 				return errors.New(msg)
 			}
 


### PR DESCRIPTION
There is no value in trying to complete remaining Slack syncs if the context has expired.